### PR TITLE
feat(tasks): add inline completion notes when marking tasks done

### DIFF
--- a/backend/src/main/java/com/taskecho/controller/TaskController.java
+++ b/backend/src/main/java/com/taskecho/controller/TaskController.java
@@ -42,7 +42,8 @@ public class TaskController {
         Task.Priority priority = body.containsKey("priority")
             ? Task.Priority.valueOf(body.get("priority").toUpperCase())
             : null;
-        return taskService.update(id, status, priority);
+        String note = body.getOrDefault("note", null);
+        return taskService.update(id, status, priority, note);
     }
 
     @GetMapping("/stats/weekly")

--- a/backend/src/main/java/com/taskecho/service/TaskService.java
+++ b/backend/src/main/java/com/taskecho/service/TaskService.java
@@ -22,7 +22,7 @@ public class TaskService {
         return new ArrayList<>(store.values());
     }
 
-    public Task update(String id, Task.Status status, Task.Priority priority) {
+    public Task update(String id, Task.Status status, Task.Priority priority, String note) {
         Task task = store.get(id);
         if (task == null) throw new IllegalArgumentException("Task not found: " + id);
 
@@ -30,8 +30,10 @@ public class TaskService {
             task.setStatus(status);
             if (status == Task.Status.COMPLETED) {
                 task.setCompletedAt(Instant.now());
+                task.setCompletionNote(note);
             } else {
                 task.setCompletedAt(null);
+                task.setCompletionNote(null);
             }
         }
         if (priority != null) {

--- a/docs/features/completion-notes.md
+++ b/docs/features/completion-notes.md
@@ -1,0 +1,132 @@
+# Completion Notes
+
+**Status:** In Development  
+**Version:** 1.3.0  
+**Branch:** `feat/completion-notes`  
+**Date:** May 2026
+
+---
+
+## Functional Changes
+
+- When a user clicks the checkbox on a pending task, the task card **expands inline** to reveal a note panel instead of completing immediately
+- The note panel contains a textarea with placeholder: *"What did you accomplish? Any blockers? (optional)"*
+- The textarea **auto-focuses** so the user can start typing immediately
+- **Enter** submits the note and completes the task; **Shift+Enter** adds a newline; **Escape** cancels
+- Two explicit action buttons: **✓ Mark Complete** (indigo) and **Cancel** (gray)
+- The note is optional — clicking Mark Complete with an empty textarea completes the task without a note
+- Completed task cards display the note in a subtle inset box beneath the title when one is present
+- Reverting a completed task back to pending (clicking the green checkbox) **clears the note**
+
+---
+
+## Technical Design
+
+### Architecture
+
+No new endpoints. The existing `PUT /tasks/{id}` now accepts an optional `note` field:
+
+```
+PUT /tasks/{id}
+Body: { "status": "COMPLETED", "note": "Optional note text" }
+```
+
+The `completionNote` field already existed on the `Task` model — this feature wires it up end-to-end for the first time.
+
+### Backend Changes
+
+**`TaskService.update()`** — signature updated to accept `String note`:
+- When `status == COMPLETED`: saves `note` to `task.completionNote` (null if omitted)
+- When `status == PENDING`: clears `completionNote` to null (reverting removes the note)
+
+**`TaskController.PUT /tasks/{id}`** — reads `note` from request body with `getOrDefault("note", null)` and passes it to the service.
+
+### Frontend State
+
+| New state | Type | Purpose |
+|---|---|---|
+| `confirmingId` | `string \| null` | ID of the task whose note panel is open |
+| `noteInput` | `string` | Current textarea value |
+
+### Function Split
+
+The previous single `toggleStatus()` was split into three focused functions:
+
+| Function | Trigger | Does |
+|---|---|---|
+| `requestComplete(task)` | Checkbox click on PENDING task | Sets `confirmingId`, clears `noteInput` |
+| `completeWithNote(task)` | Mark Complete button / Enter key | Calls API with `status + note`, clears `confirmingId` |
+| `revertToPending(task)` | Checkbox click on COMPLETED task | Calls API with `status: PENDING`, backend clears note |
+| `cancelConfirm()` | Cancel button / Escape key | Clears `confirmingId` and `noteInput`, no API call |
+
+### UX Detail — Card Expansion
+
+When `confirmingId === task.id` the card:
+- Gets an indigo border and shadow (`border-indigo-300 shadow-indigo-100`) to signal active state
+- Checkbox button turns light indigo to show it is "engaged"
+- A border-top divider separates the note panel from the task row
+- The textarea renders with `autoFocus` so no extra click is needed
+
+---
+
+## Tech Decisions & Rationale
+
+### Inline panel vs modal
+
+**Decision:** Expand the task card inline rather than open a modal dialog.
+
+**Why:** A modal interrupts the user's spatial context and requires an overlay. Inline expansion keeps the note visually attached to the task, making the connection clear. It also works better on mobile where modals can obscure the keyboard.
+
+### Note is optional, no separate "skip" button
+
+**Decision:** Mark Complete works with an empty textarea; there is no separate "Complete without note" button.
+
+**Why:** Adding a second button creates a decision burden for every completion. Making the single button work for both cases (empty = no note, filled = with note) keeps the UI minimal. The `(optional)` label communicates this clearly.
+
+### Note cleared on revert
+
+**Decision:** When a task is reverted to PENDING, its `completionNote` is cleared server-side.
+
+**Why:** A note written for a completion attempt is no longer accurate if the task is uncompleted. Preserving it would show stale context the next time the task is completed. Starting fresh is cleaner.
+
+### Enter submits, Shift+Enter newlines
+
+**Decision:** Plain Enter submits the form; Shift+Enter inserts a line break.
+
+**Why:** Notes are expected to be short (one or two sentences). The dominant use case is quick submission, so Enter-to-submit is the right default. Power users who want multi-line notes can use Shift+Enter.
+
+---
+
+## Implementation Details
+
+**Files modified:**
+
+| File | Change |
+|---|---|
+| `backend/.../service/TaskService.java` | `update()` signature + note save/clear logic |
+| `backend/.../controller/TaskController.java` | Read `note` from request body |
+| `frontend/src/app/page.tsx` | State, function split, inline note panel JSX, note display on completed cards |
+
+**No changes to:** `types.ts` (Task already had `completionNote: string | null`), `globals.css`, `layout.tsx`, any backend model file.
+
+---
+
+## Testing Recommendations
+
+- [ ] Click checkbox on pending task — note panel expands, textarea focuses
+- [ ] Type a note, press **Enter** — task moves to Completed, note appears on card
+- [ ] Click checkbox on pending task, leave textarea empty, click **Mark Complete** — task completes with no note shown
+- [ ] Click checkbox on pending task, press **Escape** — panel collapses, task stays pending
+- [ ] Click checkbox on pending task, click **Cancel** — panel collapses, task stays pending
+- [ ] Click the green checkbox on a completed task — task reverts to pending, note is gone
+- [ ] Complete the same task again with a different note — new note shown
+- [ ] Very long note — textarea should not overflow card
+- [ ] Mobile (375px) — panel fits within card width, Mark Complete button is tappable
+
+---
+
+## Deployment Notes
+
+- No database migrations (in-memory store)
+- No new environment variables
+- No breaking changes — `note` field in `PUT /tasks/{id}` is optional; existing clients that omit it continue to work

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -42,8 +42,10 @@ export default function Home() {
   const [priority, setPriority]       = useState<TaskPriority>("MEDIUM");
   const [loading, setLoading]         = useState(true);
   const [error, setError]             = useState<string | null>(null);
-  const [animatingId, setAnimatingId] = useState<string | null>(null);
-  const [filterToday, setFilterToday] = useState(false);
+  const [animatingId, setAnimatingId]     = useState<string | null>(null);
+  const [confirmingId, setConfirmingId]   = useState<string | null>(null);
+  const [noteInput, setNoteInput]         = useState("");
+  const [filterToday, setFilterToday]     = useState(false);
   const [sortByPriority, setSortByPriority] = useState(false);
   const [showAllPending, setShowAllPending] = useState(false);
 
@@ -75,14 +77,43 @@ export default function Home() {
     } catch (e) { setError((e as Error).message); }
   }
 
-  async function toggleStatus(task: Task) {
-    const newStatus = task.status === "PENDING" ? "COMPLETED" : "PENDING";
+  function requestComplete(task: Task) {
+    setConfirmingId(task.id);
+    setNoteInput("");
+  }
+
+  function cancelConfirm() {
+    setConfirmingId(null);
+    setNoteInput("");
+  }
+
+  async function completeWithNote(task: Task) {
+    setConfirmingId(null);
+    setAnimatingId(task.id);
+    try {
+      const body: Record<string, string> = { status: "COMPLETED" };
+      if (noteInput.trim()) body.note = noteInput.trim();
+      const res = await fetch(`${API}/${task.id}`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      });
+      if (!res.ok) throw new Error(`${res.status}`);
+      const updated = (await res.json()) as Task;
+      setTasks(prev => prev.map(t => t.id === task.id ? updated : t));
+      setNoteInput("");
+      refreshStats();
+    } catch (e) { setError((e as Error).message); }
+    finally { setTimeout(() => setAnimatingId(null), 300); }
+  }
+
+  async function revertToPending(task: Task) {
     setAnimatingId(task.id);
     try {
       const res = await fetch(`${API}/${task.id}`, {
         method: "PUT",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ status: newStatus }),
+        body: JSON.stringify({ status: "PENDING" }),
       });
       if (!res.ok) throw new Error(`${res.status}`);
       const updated = (await res.json()) as Task;
@@ -263,30 +294,77 @@ export default function Home() {
                   )}
                 </div>
                 <div className="space-y-2">
-                  {displayedPending.map(task => (
-                    <div
-                      key={task.id}
-                      className={`bg-white rounded-xl border border-gray-100 shadow-sm px-4 py-3.5 flex items-center gap-3 hover:shadow-md transition-all duration-200 ${
-                        animatingId === task.id ? "opacity-50 scale-95" : ""
-                      }`}
-                    >
-                      <button
-                        onClick={() => toggleStatus(task)}
-                        className="w-5 h-5 rounded border-2 border-gray-300 hover:border-indigo-500 flex-shrink-0 transition-colors"
-                        aria-label={`Complete ${task.title}`}
-                      />
-                      <div className="flex-1 min-w-0">
-                        <p className="text-sm font-medium text-gray-900 truncate">{task.title}</p>
-                        <p className="text-xs text-gray-400 mt-0.5 flex items-center gap-1">
-                          <span>📅</span>
-                          {fmtDate(task.createdAt)}
-                        </p>
+                  {displayedPending.map(task => {
+                    const isConfirming = confirmingId === task.id;
+                    return (
+                      <div
+                        key={task.id}
+                        className={`bg-white rounded-xl border shadow-sm transition-all duration-200 ${
+                          isConfirming ? "border-indigo-300 shadow-indigo-100" : "border-gray-100 hover:shadow-md"
+                        } ${animatingId === task.id ? "opacity-50 scale-95" : ""}`}
+                      >
+                        {/* Main task row */}
+                        <div className="px-4 py-3.5 flex items-center gap-3">
+                          <button
+                            onClick={() => isConfirming ? cancelConfirm() : requestComplete(task)}
+                            className={`w-5 h-5 rounded border-2 flex-shrink-0 transition-colors ${
+                              isConfirming
+                                ? "border-indigo-500 bg-indigo-50"
+                                : "border-gray-300 hover:border-indigo-500"
+                            }`}
+                            aria-label={`Complete ${task.title}`}
+                          />
+                          <div className="flex-1 min-w-0">
+                            <p className="text-sm font-medium text-gray-900 truncate">{task.title}</p>
+                            <p className="text-xs text-gray-400 mt-0.5 flex items-center gap-1">
+                              <span>📅</span>
+                              {fmtDate(task.createdAt)}
+                            </p>
+                          </div>
+                          <span className={`text-xs font-medium px-2 py-0.5 rounded-full ${PRIORITY_COLOR[task.priority]}`}>
+                            {PRIORITY_LABEL[task.priority]}
+                          </span>
+                        </div>
+
+                        {/* Inline note panel — shown when confirming */}
+                        {isConfirming && (
+                          <div className="px-4 pb-4 animate-fade-in">
+                            <div className="border-t border-indigo-100 pt-3">
+                              <p className="text-xs font-medium text-indigo-700 mb-2">
+                                Add a completion note <span className="text-gray-400 font-normal">(optional)</span>
+                              </p>
+                              <textarea
+                                autoFocus
+                                rows={2}
+                                value={noteInput}
+                                onChange={e => setNoteInput(e.target.value)}
+                                onKeyDown={e => {
+                                  if (e.key === "Enter" && !e.shiftKey) { e.preventDefault(); completeWithNote(task); }
+                                  if (e.key === "Escape") cancelConfirm();
+                                }}
+                                placeholder="What did you accomplish? Any blockers? (optional)"
+                                className="w-full text-sm text-gray-800 placeholder-gray-400 bg-gray-50 border border-gray-200 rounded-lg px-3 py-2 resize-none focus:outline-none focus:ring-2 focus:ring-indigo-400 focus:border-transparent transition-all"
+                              />
+                              <div className="flex gap-2 mt-2">
+                                <button
+                                  onClick={() => completeWithNote(task)}
+                                  className="flex-1 py-1.5 bg-indigo-600 hover:bg-indigo-700 text-white text-xs font-semibold rounded-lg transition-colors active:scale-95"
+                                >
+                                  ✓ Mark Complete
+                                </button>
+                                <button
+                                  onClick={cancelConfirm}
+                                  className="px-4 py-1.5 bg-gray-100 hover:bg-gray-200 text-gray-600 text-xs font-medium rounded-lg transition-colors"
+                                >
+                                  Cancel
+                                </button>
+                              </div>
+                            </div>
+                          </div>
+                        )}
                       </div>
-                      <span className={`text-xs font-medium px-2 py-0.5 rounded-full ${PRIORITY_COLOR[task.priority]}`}>
-                        {PRIORITY_LABEL[task.priority]}
-                      </span>
-                    </div>
-                  ))}
+                    );
+                  })}
                 </div>
               </section>
             )}
@@ -306,29 +384,39 @@ export default function Home() {
                   {completed.map(task => (
                     <div
                       key={task.id}
-                      className={`bg-emerald-50 rounded-xl border border-emerald-100 px-4 py-3.5 flex items-center gap-3 transition-all duration-200 ${
+                      className={`bg-emerald-50 rounded-xl border border-emerald-100 px-4 py-3.5 transition-all duration-200 ${
                         animatingId === task.id ? "opacity-50 scale-95" : ""
                       }`}
                     >
-                      <button
-                        onClick={() => toggleStatus(task)}
-                        className="w-5 h-5 rounded border-2 border-emerald-500 bg-emerald-500 flex-shrink-0 flex items-center justify-center transition-colors hover:bg-emerald-400"
-                        aria-label={`Undo ${task.title}`}
-                      >
-                        <svg className="w-3 h-3 text-white" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={3}>
-                          <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
-                        </svg>
-                      </button>
-                      <div className="flex-1 min-w-0">
-                        <p className="text-sm text-gray-400 line-through truncate">{task.title}</p>
-                        <p className="text-xs text-gray-400 mt-0.5 flex items-center gap-1">
-                          <span>✓</span>
-                          {task.completedAt ? fmtDate(task.completedAt) : fmtDate(task.createdAt)}
-                        </p>
+                      <div className="flex items-center gap-3">
+                        <button
+                          onClick={() => revertToPending(task)}
+                          className="w-5 h-5 rounded border-2 border-emerald-500 bg-emerald-500 flex-shrink-0 flex items-center justify-center transition-colors hover:bg-emerald-400"
+                          aria-label={`Undo ${task.title}`}
+                        >
+                          <svg className="w-3 h-3 text-white" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={3}>
+                            <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
+                          </svg>
+                        </button>
+                        <div className="flex-1 min-w-0">
+                          <p className="text-sm text-gray-400 line-through truncate">{task.title}</p>
+                          <p className="text-xs text-gray-400 mt-0.5 flex items-center gap-1">
+                            <span>✓</span>
+                            {task.completedAt ? fmtDate(task.completedAt) : fmtDate(task.createdAt)}
+                          </p>
+                        </div>
+                        <span className={`text-xs font-medium px-2 py-0.5 rounded-full ${PRIORITY_COLOR[task.priority]}`}>
+                          {PRIORITY_LABEL[task.priority]}
+                        </span>
                       </div>
-                      <span className={`text-xs font-medium px-2 py-0.5 rounded-full ${PRIORITY_COLOR[task.priority]}`}>
-                        {PRIORITY_LABEL[task.priority]}
-                      </span>
+                      {task.completionNote && (
+                        <div className="mt-2 ml-8 px-3 py-2 bg-white border border-emerald-100 rounded-lg">
+                          <p className="text-xs text-gray-500 leading-relaxed">
+                            <span className="font-medium text-emerald-600">Note: </span>
+                            {task.completionNote}
+                          </p>
+                        </div>
+                      )}
                     </div>
                   ))}
                 </div>


### PR DESCRIPTION
## Summary

When a user marks a task as complete, an inline note panel now expands on the card so they can optionally record what they accomplished. The note is saved with the task and displayed on the completed card. No new endpoints — the existing `completionNote` field on `Task` is finally wired up end-to-end.

## Changes

### Backend
- **`TaskService.update()`** — added `note` parameter; saves it as `completionNote` on COMPLETED, clears it on revert to PENDING
- **`TaskController`** — reads optional `note` field from `PUT /tasks/{id}` request body

### Frontend
- **Inline note panel** — clicking a pending task's checkbox expands the card with a textarea (auto-focused), "✓ Mark Complete" and "Cancel" buttons
- **Keyboard shortcuts** — Enter submits, Shift+Enter adds newline, Escape cancels
- **Note is optional** — Mark Complete with empty textarea completes without a note; no separate skip button needed
- **Note display** — completed task cards show the note in a subtle inset box beneath the title when present; no visual change when absent
- **Revert clears note** — clicking the green checkbox on a completed task reverts it to pending and the backend clears the note
- **Function split** — replaced single `toggleStatus()` with `requestComplete` / `completeWithNote` / `revertToPending` / `cancelConfirm` for clarity

## Technical Details

**Files Modified:**
- `backend/.../service/TaskService.java`
- `backend/.../controller/TaskController.java`
- `frontend/src/app/page.tsx`

**Files Created:**
- `docs/features/completion-notes.md`

**API change (backwards compatible):**
`PUT /tasks/{id}` — body now accepts optional `note: string` field. Existing callers that omit it are unaffected.

**Breaking Changes:** None.

## How to Test

1. `cd backend && mvn spring-boot:run`
2. `cd frontend && npm run dev` → open `http://localhost:3000`
3. Add a task, then click its checkbox — note panel should expand with auto-focus
4. Type a note and press **Enter** (or click Mark Complete) — task moves to Completed with note shown
5. Try clicking Mark Complete with **empty textarea** — task completes with no note
6. Press **Escape** or **Cancel** — panel collapses, task stays pending
7. Click the green checkbox on a completed task — reverts to pending, note gone

## Checklist
- [x] Code follows project style guidelines
- [x] Documentation updated (`docs/features/completion-notes.md`)
- [x] No breaking changes
- [x] Manually tested all flows (complete with note, without note, cancel, revert)
- [x] No hardcoded values or secrets