### PR TITLE
feat(tasks): add subtasks with cascade completion

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,9 +98,12 @@ curl -s -X POST http://localhost:8080/tasks \
   "id": "a1b2c3...",
   "title": "My first task",
   "status": "PENDING",
+  "priority": "MEDIUM",
   "createdAt": "2026-05-01T10:00:00Z",
   "completedAt": null,
-  "completionNote": null
+  "completionNote": null,
+  "tags": [],
+  "subtasks": []
 }
 ```
 
@@ -108,6 +111,28 @@ curl -s -X POST http://localhost:8080/tasks \
 
 ```bash
 curl -s http://localhost:8080/tasks | jq
+```
+
+### Add a subtask
+
+```bash
+curl -s -X POST http://localhost:8080/tasks/{id}/subtasks \
+  -H "Content-Type: application/json" \
+  -d '{"title": "Write unit tests"}' | jq
+```
+
+### Toggle subtask completion
+
+```bash
+curl -s -X PUT http://localhost:8080/tasks/{id}/subtasks/{subtaskId} \
+  -H "Content-Type: application/json" \
+  -d '{"status": "COMPLETED"}' | jq
+```
+
+### Delete a subtask
+
+```bash
+curl -s -X DELETE http://localhost:8080/tasks/{id}/subtasks/{subtaskId} | jq
 ```
 
 ## Troubleshooting

--- a/backend/src/main/java/com/taskecho/controller/TaskController.java
+++ b/backend/src/main/java/com/taskecho/controller/TaskController.java
@@ -48,4 +48,29 @@ public class TaskController {
     public List<Map<String, Object>> weeklyStats() {
         return taskService.getWeeklyStats();
     }
+
+    // ── Subtask endpoints ─────────────────────────────────────────────────────
+
+    @PostMapping("/{id}/subtasks")
+    @ResponseStatus(HttpStatus.CREATED)
+    public Task addSubtask(@PathVariable String id, @RequestBody TaskRequest body) {
+        return taskService.addSubtask(id, body.getTitle());
+    }
+
+    @PutMapping("/{id}/subtasks/{subtaskId}")
+    public Task updateSubtask(
+        @PathVariable String id,
+        @PathVariable String subtaskId,
+        @RequestBody TaskRequest body
+    ) {
+        Task.Status status = body.getStatus() != null
+            ? Task.Status.valueOf(body.getStatus().toUpperCase())
+            : null;
+        return taskService.updateSubtask(id, subtaskId, status);
+    }
+
+    @DeleteMapping("/{id}/subtasks/{subtaskId}")
+    public Task deleteSubtask(@PathVariable String id, @PathVariable String subtaskId) {
+        return taskService.deleteSubtask(id, subtaskId);
+    }
 }

--- a/backend/src/main/java/com/taskecho/model/Subtask.java
+++ b/backend/src/main/java/com/taskecho/model/Subtask.java
@@ -1,0 +1,34 @@
+package com.taskecho.model;
+
+import java.time.Instant;
+import java.util.UUID;
+
+public class Subtask {
+
+    private final String    id;
+    private String          title;
+    private Task.Status     status;
+    private final Instant   createdAt;
+    private Instant         completedAt;
+
+    public Subtask(String title) {
+        this.id        = UUID.randomUUID().toString();
+        this.title     = title;
+        this.status    = Task.Status.PENDING;
+        this.createdAt = Instant.now();
+    }
+
+    // ── Getters ──────────────────────────────────────────────────────────────
+
+    public String      getId()          { return id; }
+    public String      getTitle()       { return title; }
+    public Task.Status getStatus()      { return status; }
+    public Instant     getCreatedAt()   { return createdAt; }
+    public Instant     getCompletedAt() { return completedAt; }
+
+    // ── Setters ──────────────────────────────────────────────────────────────
+
+    public void setTitle(String title)              { this.title = title; }
+    public void setStatus(Task.Status status)       { this.status = status; }
+    public void setCompletedAt(Instant completedAt) { this.completedAt = completedAt; }
+}

--- a/backend/src/main/java/com/taskecho/model/Task.java
+++ b/backend/src/main/java/com/taskecho/model/Task.java
@@ -19,6 +19,7 @@ public class Task {
     private Instant        completedAt;
     private String         completionNote;
     private List<String>   tags;
+    private List<Subtask>  subtasks;
 
     public Task(String title, Priority priority) {
         this.id        = UUID.randomUUID().toString();
@@ -27,6 +28,7 @@ public class Task {
         this.priority  = priority != null ? priority : Priority.MEDIUM;
         this.createdAt = Instant.now();
         this.tags      = new ArrayList<>();
+        this.subtasks  = new ArrayList<>();
     }
 
     // ── Getters ──────────────────────────────────────────────────────────────
@@ -39,6 +41,7 @@ public class Task {
     public Instant       getCompletedAt()    { return completedAt; }
     public String        getCompletionNote() { return completionNote; }
     public List<String>  getTags()           { return Collections.unmodifiableList(tags); }
+    public List<Subtask> getSubtasks()       { return Collections.unmodifiableList(subtasks); }
 
     // ── Setters ──────────────────────────────────────────────────────────────
 
@@ -48,4 +51,9 @@ public class Task {
     public void setCompletedAt(Instant completedAt)      { this.completedAt = completedAt; }
     public void setCompletionNote(String completionNote) { this.completionNote = completionNote; }
     public void setTags(List<String> tags)               { this.tags = tags != null ? new ArrayList<>(tags) : new ArrayList<>(); }
+
+    // ── Subtask mutation (called by service only) ─────────────────────────────
+
+    public void addSubtask(Subtask subtask)       { subtasks.add(subtask); }
+    public void removeSubtask(String subtaskId)   { subtasks.removeIf(s -> s.getId().equals(subtaskId)); }
 }

--- a/backend/src/main/java/com/taskecho/service/TaskService.java
+++ b/backend/src/main/java/com/taskecho/service/TaskService.java
@@ -1,5 +1,6 @@
 package com.taskecho.service;
 
+import com.taskecho.model.Subtask;
 import com.taskecho.model.Task;
 import org.springframework.stereotype.Service;
 
@@ -45,6 +46,13 @@ public class TaskService {
             if (status == Task.Status.COMPLETED) {
                 task.setCompletedAt(Instant.now());
                 task.setCompletionNote(note);
+                // Cascade completion to all pending subtasks
+                task.getSubtasks().forEach(s -> {
+                    if (s.getStatus() != Task.Status.COMPLETED) {
+                        s.setStatus(Task.Status.COMPLETED);
+                        s.setCompletedAt(Instant.now());
+                    }
+                });
             } else {
                 task.setCompletedAt(null);
                 task.setCompletionNote(null);
@@ -58,6 +66,43 @@ public class TaskService {
         }
         return task;
     }
+
+    // ── Subtask operations ────────────────────────────────────────────────────
+
+    public Task addSubtask(String taskId, String title) {
+        Task task = store.get(taskId);
+        if (task == null) throw new IllegalArgumentException("Task not found: " + taskId);
+        if (task.getStatus() == Task.Status.COMPLETED) {
+            throw new IllegalStateException("Cannot add subtask to a completed task");
+        }
+        task.addSubtask(new Subtask(title.trim()));
+        return task;
+    }
+
+    public Task updateSubtask(String taskId, String subtaskId, Task.Status status) {
+        Task task = store.get(taskId);
+        if (task == null) throw new IllegalArgumentException("Task not found: " + taskId);
+
+        Subtask subtask = task.getSubtasks().stream()
+            .filter(s -> s.getId().equals(subtaskId))
+            .findFirst()
+            .orElseThrow(() -> new IllegalArgumentException("Subtask not found: " + subtaskId));
+
+        if (status != null) {
+            subtask.setStatus(status);
+            subtask.setCompletedAt(status == Task.Status.COMPLETED ? Instant.now() : null);
+        }
+        return task;
+    }
+
+    public Task deleteSubtask(String taskId, String subtaskId) {
+        Task task = store.get(taskId);
+        if (task == null) throw new IllegalArgumentException("Task not found: " + taskId);
+        task.removeSubtask(subtaskId);
+        return task;
+    }
+
+    // ── Weekly stats ──────────────────────────────────────────────────────────
 
     public List<Map<String, Object>> getWeeklyStats() {
         ZoneId zone = ZoneId.systemDefault();

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -85,6 +85,29 @@ This document tracks all features implemented in TaskEcho, their status, and whe
 
 ---
 
+### 5. Subtasks
+**Status:** In Development  
+**Version:** 1.5.0  
+**Branch:** `feat/subtasks`  
+**Date:** May 2026
+
+**Features:**
+- Add subtasks to any pending task via a 3-dot menu (⋮) on the task card
+- Toggle individual subtask completion (checkbox + strikethrough)
+- Completing the main task auto-completes all pending subtasks
+- Subtask progress counter (`x/y subtasks`) in the task meta line
+- Inline warning when completing a task with pending subtasks
+- Completed tasks show all subtasks in the "More details" section
+
+**Details:** [Subtasks Feature](features/subtasks.md)
+
+**API Changes:**
+- New: `POST /tasks/{id}/subtasks` — Add a subtask to a task
+- New: `PUT /tasks/{id}/subtasks/{subtaskId}` — Toggle subtask completion
+- New: `DELETE /tasks/{id}/subtasks/{subtaskId}` — Remove a subtask
+
+---
+
 ## 🚀 Upcoming Features
 
 ### Task Deletion
@@ -194,8 +217,9 @@ When proposing a new feature:
 | 1.2.0 | TBD | Task deletion | Planned |
 | 1.3.0 | TBD | Task editing | Planned |
 | 1.4.0 | May 2026 | Task tagging (max 3, expandable details) | In Development |
-| 1.5.0 | TBD | Advanced filtering | Planned |
-| 1.6.0 | TBD | Priority levels | Planned |
+| 1.5.0 | May 2026 | Subtasks (nested checklist per task) | In Development |
+| 1.6.0 | TBD | Advanced filtering | Planned |
+| 1.7.0 | TBD | Priority levels | Planned |
 | 2.0.0 | TBD | Recurring tasks | Planned |
 
 ---

--- a/docs/features/subtasks.md
+++ b/docs/features/subtasks.md
@@ -12,7 +12,7 @@ Tasks now support optional subtasks — a flat list of smaller work items nested
 
 **Key capabilities:**
 - Any existing pending task can have subtasks added at any time before it is completed
-- Subtasks are added via a **3-dot menu (⋮)** on the left of each pending task card
+- Subtasks are added via a **3-dot menu (⋮)** on the right of each pending task card (after the priority badge)
 - Each subtask has its own checkbox; checking it marks only that subtask complete (strikethrough + filled checkbox)
 - Unchecking a completed subtask reverts it to pending
 - Completing the **main task** cascades completion to all subtasks automatically
@@ -23,7 +23,7 @@ Tasks now support optional subtasks — a flat list of smaller work items nested
 
 **User workflow:**
 1. Create a task normally
-2. Click **⋮** → **Add Subtask** to open the inline input
+2. Click **⋮** (right side of task card) → **Add Subtask** to open the inline input
 3. Type a subtask title and press **Enter** (or click **Add**)
 4. Repeat to add more subtasks; press **Escape** or click **×** to close the input
 5. Check/uncheck individual subtasks independently

--- a/docs/features/subtasks.md
+++ b/docs/features/subtasks.md
@@ -1,0 +1,157 @@
+# Subtasks Feature
+
+**Branch:** `feat/subtasks`  
+**Date:** May 2026  
+**Version:** 1.5.0
+
+---
+
+## 1. Functional Changes
+
+Tasks now support optional subtasks — a flat list of smaller work items nested under any pending task.
+
+**Key capabilities:**
+- Any existing pending task can have subtasks added at any time before it is completed
+- Subtasks are added via a **3-dot menu (⋮)** on the left of each pending task card
+- Each subtask has its own checkbox; checking it marks only that subtask complete (strikethrough + filled checkbox)
+- Unchecking a completed subtask reverts it to pending
+- Completing the **main task** cascades completion to all subtasks automatically
+- Subtasks can be deleted individually by hovering the row and clicking the × button
+- A **progress indicator** (`x/y subtasks`) appears in the task meta line when subtasks exist
+- A **warning banner** in the completion confirm panel tells the user how many pending subtasks will be auto-completed
+- Completed task cards show subtasks (all checked/strikethrough) in the "More details" section
+
+**User workflow:**
+1. Create a task normally
+2. Click **⋮** → **Add Subtask** to open the inline input
+3. Type a subtask title and press **Enter** (or click **Add**)
+4. Repeat to add more subtasks; press **Escape** or click **×** to close the input
+5. Check/uncheck individual subtasks independently
+6. Marking the main task complete auto-completes all remaining subtasks
+
+---
+
+## 2. Technical Design
+
+### Backend
+
+**New model:** `Subtask.java`
+- Fields: `id` (UUID), `title`, `status` (`PENDING`/`COMPLETED`, reuses `Task.Status`), `createdAt`, `completedAt`
+- Mutated directly by the service (no separate repository layer)
+
+**Updated `Task.java`:**
+- New field: `List<Subtask> subtasks` (initialized as empty `ArrayList`)
+- Getter returns `Collections.unmodifiableList` (read-only for callers)
+- Mutation via package-internal methods: `addSubtask(Subtask)`, `removeSubtask(String id)`
+
+**Updated `TaskService.java`:**
+- `addSubtask(taskId, title)` — creates and appends a `Subtask`; throws `IllegalStateException` if the parent task is already `COMPLETED`
+- `updateSubtask(taskId, subtaskId, status)` — toggles `status` and sets/clears `completedAt`
+- `deleteSubtask(taskId, subtaskId)` — removes the subtask by ID
+- `update()` cascade — when a task is marked `COMPLETED`, iterates `task.getSubtasks()` and completes any still-pending ones (subtask objects are mutable even through the unmodifiable list view)
+
+**New API endpoints in `TaskController.java`:**
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| `POST` | `/tasks/{id}/subtasks` | Add a subtask; body: `{ "title": "..." }` |
+| `PUT` | `/tasks/{id}/subtasks/{subtaskId}` | Update subtask status; body: `{ "status": "COMPLETED" }` |
+| `DELETE` | `/tasks/{id}/subtasks/{subtaskId}` | Remove a subtask |
+
+All three endpoints return the full updated `Task` object so the frontend can replace the task in state without additional fetches.
+
+### Frontend
+
+**Updated `types.ts`:**
+- New `Subtask` interface: `{ id, title, status, createdAt, completedAt }`
+- `Task.subtasks: Subtask[]` field added
+
+**New `SubtaskRow` component** (inline in `page.tsx`):
+- Renders a small checkbox (4×4, same visual language as the main task checkbox)
+- Title text with `line-through text-gray-400` when `COMPLETED`
+- Delete button (×) hidden by default, shown on group hover
+
+**State additions to `Home`:**
+- `activeMenuId: string | null` — which task's 3-dot menu is open
+- `addingSubtaskForId: string | null` — which task is showing the inline subtask input
+- `subtaskInput: string` — controlled value for the inline input
+
+**Outside-click handling:**
+```typescript
+useEffect(() => {
+  if (!activeMenuId) return;
+  const close = () => setActiveMenuId(null);
+  document.addEventListener("click", close);
+  return () => document.removeEventListener("click", close);
+}, [activeMenuId]);
+```
+The ⋮ button uses `e.stopPropagation()` to prevent immediately closing the menu it just opened.
+
+**Subtask input UX:**
+- Inline input opens below the subtask list inside the task card
+- Enter → add and keep input open (user can keep adding)
+- Escape / × → close input
+- After adding, `subtaskInput` clears but `addingSubtaskForId` stays set
+
+---
+
+## 3. Tech Decisions & Rationale
+
+**Flat list (not recursive subtasks)**
+Subtasks are a single level deep. Recursive subtask trees add significant complexity (rendering, completion cascade logic, API design) for minimal benefit in a task manager of this scope.
+
+**Backend cascade, not frontend**
+When the main task is marked complete, the cascade to all subtasks happens in `TaskService.update()` and the updated task (with all subtasks now `COMPLETED`) is returned. The frontend simply replaces the task in state — no extra API calls needed.
+
+**Subtask objects mutable through `unmodifiableList`**
+`Collections.unmodifiableList` prevents `add/remove` on the list wrapper, but the `Subtask` objects inside are plain mutable POJOs. The service iterates the unmodifiable view and calls `setStatus()`/`setCompletedAt()` directly on each subtask — this is intentional and correct. The `addSubtask`/`removeSubtask` methods on `Task` bypass the wrapper and mutate the backing `ArrayList`.
+
+**Return full `Task` from subtask endpoints**
+All three subtask endpoints (`POST`, `PUT`, `DELETE`) return the updated parent `Task`. This means the frontend always has the full consistent state (subtask list, task status) in a single response and can update via `setTasks(prev => prev.map(...))`.
+
+**Add subtask only allowed on PENDING tasks**
+Enforced on the backend (`IllegalStateException` if task is `COMPLETED`) and implicitly on the frontend (the ⋮ menu only appears on pending task cards). There is no way to add subtasks to a completed task.
+
+**Subtask delete is instant (no confirm step)**
+The main task uses a two-step completion confirmation with a note. Subtask deletion has no such confirmation — it's a lower-stakes destructive action and inline undo support would add complexity. The × delete button is also hidden behind a hover state to reduce accidental clicks.
+
+---
+
+## 4. Implementation Details
+
+**Files created:**
+- `backend/src/main/java/com/taskecho/model/Subtask.java`
+
+**Files modified:**
+- `backend/src/main/java/com/taskecho/model/Task.java` — added `subtasks` field, `addSubtask`, `removeSubtask`
+- `backend/src/main/java/com/taskecho/service/TaskService.java` — added `addSubtask`, `updateSubtask`, `deleteSubtask`; cascade in `update()`
+- `backend/src/main/java/com/taskecho/controller/TaskController.java` — three new subtask endpoints
+- `frontend/src/app/types.ts` — `Subtask` interface, `Task.subtasks` field
+- `frontend/src/app/page.tsx` — `SubtaskRow` component, state, handlers, updated task card JSX
+
+---
+
+## 5. Testing Recommendations
+
+**Backend:**
+- `POST /tasks/{id}/subtasks` adds subtask and returns updated task
+- `PUT /tasks/{id}/subtasks/{subtaskId}` with `COMPLETED` sets `completedAt`; with `PENDING` clears it
+- `DELETE /tasks/{id}/subtasks/{subtaskId}` removes subtask from returned task
+- `PUT /tasks/{id}` with `COMPLETED` cascades to all pending subtasks
+- `POST /tasks/{id}/subtasks` on a `COMPLETED` task returns 500 with error message
+
+**Frontend:**
+- ⋮ menu opens and closes on click; closes on outside click
+- "Add Subtask" opens inline input; Enter adds and keeps input open; Escape closes
+- Checking a subtask checkbox updates only that subtask (strikethrough)
+- Unchecking a completed subtask reverts it
+- Completing the main task: warning shows, all subtasks shown as complete in "More details"
+- Completed task "More details" shows all subtasks strikethrough
+- Subtask progress counter updates in real time (`x/y subtasks`)
+- Hover on a subtask row reveals × delete button; clicking removes the subtask
+
+---
+
+## 6. Deployment Notes
+
+No schema migrations (in-memory store). Restarting the backend resets all data including subtasks — same behaviour as the rest of the app.

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useEffect, useMemo, useRef } from "react";
-import type { Task, TaskPriority, DayStat } from "./types";
+import type { Task, Subtask, TaskPriority, DayStat } from "./types";
 
 const API = "http://localhost:8080/tasks";
 const MAX_TAGS = 3;
@@ -78,6 +78,50 @@ function TagPill({
   );
 }
 
+// ── Single subtask row (used in pending task cards) ───────────────────────
+function SubtaskRow({
+  subtask,
+  taskId,
+  onToggle,
+  onDelete,
+}: {
+  subtask: Subtask;
+  taskId: string;
+  onToggle: (taskId: string, subtask: Subtask) => void;
+  onDelete: (taskId: string, subtaskId: string) => void;
+}) {
+  const done = subtask.status === "COMPLETED";
+  return (
+    <div className="flex items-center gap-2 group">
+      <button
+        onClick={() => onToggle(taskId, subtask)}
+        className={`w-4 h-4 rounded border-2 flex-shrink-0 flex items-center justify-center transition-colors ${
+          done
+            ? "border-emerald-500 bg-emerald-500"
+            : "border-gray-300 hover:border-indigo-400"
+        }`}
+        aria-label={done ? `Undo subtask: ${subtask.title}` : `Complete subtask: ${subtask.title}`}
+      >
+        {done && (
+          <svg className="w-2.5 h-2.5 text-white" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={3}>
+            <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
+          </svg>
+        )}
+      </button>
+      <span className={`text-xs flex-1 min-w-0 truncate ${done ? "line-through text-gray-400" : "text-gray-600"}`}>
+        {subtask.title}
+      </span>
+      <button
+        onClick={() => onDelete(taskId, subtask.id)}
+        className="opacity-0 group-hover:opacity-100 w-4 h-4 flex items-center justify-center text-gray-300 hover:text-red-400 transition-all text-base leading-none"
+        aria-label={`Delete subtask: ${subtask.title}`}
+      >
+        ×
+      </button>
+    </div>
+  );
+}
+
 export default function Home() {
   const [tasks, setTasks]               = useState<Task[]>([]);
   const [stats, setStats]               = useState<DayStat[]>([]);
@@ -101,6 +145,11 @@ export default function Home() {
   // ── Expanded details per task card ──────────────────────────────────────
   const [expandedTaskId, setExpandedTaskId] = useState<string | null>(null);
 
+  // ── Subtask state ────────────────────────────────────────────────────────
+  const [activeMenuId, setActiveMenuId]           = useState<string | null>(null);
+  const [addingSubtaskForId, setAddingSubtaskForId] = useState<string | null>(null);
+  const [subtaskInput, setSubtaskInput]           = useState("");
+
   useEffect(() => {
     Promise.all([
       fetch(API).then(r => { if (!r.ok) throw new Error(`${r.status}`); return r.json() as Promise<Task[]>; }),
@@ -110,6 +159,14 @@ export default function Home() {
       .catch((e: Error) => setError(e.message))
       .finally(() => setLoading(false));
   }, []);
+
+  // Close the 3-dot menu when clicking outside it
+  useEffect(() => {
+    if (!activeMenuId) return;
+    const close = () => setActiveMenuId(null);
+    document.addEventListener("click", close);
+    return () => document.removeEventListener("click", close);
+  }, [activeMenuId]);
 
   // ── Tag input helpers ────────────────────────────────────────────────────
   function commitTag() {
@@ -141,7 +198,6 @@ export default function Home() {
     const title = input.trim();
     if (!title) return;
 
-    // commit any in-progress tag text first
     const pendingTag = tagInput.trim().toLowerCase().replace(/^#+/, "");
     const finalTags = pendingTag && newTags.length < MAX_TAGS && !newTags.includes(pendingTag)
       ? [...newTags, pendingTag.slice(0, MAX_TAG_LENGTH)]
@@ -177,6 +233,7 @@ export default function Home() {
 
   async function completeWithNote(task: Task) {
     setConfirmingId(null);
+    setAddingSubtaskForId(null);
     setAnimatingId(task.id);
     try {
       const body: Record<string, unknown> = { status: "COMPLETED" };
@@ -209,6 +266,50 @@ export default function Home() {
       refreshStats();
     } catch (e) { setError((e as Error).message); }
     finally { setTimeout(() => setAnimatingId(null), 300); }
+  }
+
+  // ── Subtask operations ────────────────────────────────────────────────────
+
+  async function addSubtask(taskId: string) {
+    const title = subtaskInput.trim();
+    if (!title) return;
+    try {
+      const res = await fetch(`${API}/${taskId}/subtasks`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ title }),
+      });
+      if (!res.ok) throw new Error(`${res.status}`);
+      const updated = (await res.json()) as Task;
+      setTasks(prev => prev.map(t => t.id === taskId ? updated : t));
+      setSubtaskInput("");
+      // Keep input open so user can add more
+    } catch (e) { setError((e as Error).message); }
+  }
+
+  async function toggleSubtask(taskId: string, subtask: Subtask) {
+    const newStatus = subtask.status === "COMPLETED" ? "PENDING" : "COMPLETED";
+    try {
+      const res = await fetch(`${API}/${taskId}/subtasks/${subtask.id}`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ status: newStatus }),
+      });
+      if (!res.ok) throw new Error(`${res.status}`);
+      const updated = (await res.json()) as Task;
+      setTasks(prev => prev.map(t => t.id === taskId ? updated : t));
+    } catch (e) { setError((e as Error).message); }
+  }
+
+  async function deleteSubtask(taskId: string, subtaskId: string) {
+    try {
+      const res = await fetch(`${API}/${taskId}/subtasks/${subtaskId}`, {
+        method: "DELETE",
+      });
+      if (!res.ok) throw new Error(`${res.status}`);
+      const updated = (await res.json()) as Task;
+      setTasks(prev => prev.map(t => t.id === taskId ? updated : t));
+    } catch (e) { setError((e as Error).message); }
   }
 
   async function refreshStats() {
@@ -327,7 +428,7 @@ export default function Home() {
               />
             </div>
 
-            {/* Tag expansion area — sits between input and toolbar */}
+            {/* Tag expansion area */}
             {showDetails && (
               <div className="px-4 pb-2.5 border-t border-dashed border-gray-200 pt-2.5">
                 <div className="flex flex-wrap items-center gap-1.5">
@@ -353,10 +454,9 @@ export default function Home() {
               </div>
             )}
 
-            {/* Toolbar row — always visible */}
+            {/* Toolbar row */}
             <div className="px-3 py-2 border-t border-gray-100 flex items-center justify-between gap-2">
               <div className="flex items-center gap-1">
-                {/* Priority */}
                 <select
                   value={priority}
                   onChange={e => setPriority(e.target.value as TaskPriority)}
@@ -367,10 +467,8 @@ export default function Home() {
                   <option value="HIGH">High priority</option>
                 </select>
 
-                {/* Divider */}
                 <span className="w-px h-3.5 bg-gray-200 mx-1" />
 
-                {/* Tags toggle */}
                 <button
                   type="button"
                   onClick={() => {
@@ -395,7 +493,6 @@ export default function Home() {
                 </button>
               </div>
 
-              {/* Add Task button */}
               <button
                 onClick={addTask}
                 disabled={loading || !input.trim()}
@@ -444,9 +541,13 @@ export default function Home() {
                 </div>
                 <div className="space-y-2">
                   {displayedPending.map(task => {
-                    const isConfirming  = confirmingId === task.id;
-                    const isExpanded    = expandedTaskId === task.id;
-                    const hasTags       = task.tags && task.tags.length > 0;
+                    const isConfirming     = confirmingId === task.id;
+                    const isExpanded       = expandedTaskId === task.id;
+                    const hasTags          = task.tags && task.tags.length > 0;
+                    const hasSubtasks      = task.subtasks && task.subtasks.length > 0;
+                    const isAddingSubtask  = addingSubtaskForId === task.id;
+                    const doneSubtasks     = task.subtasks?.filter(s => s.status === "COMPLETED").length ?? 0;
+                    const totalSubtasks    = task.subtasks?.length ?? 0;
                     return (
                       <div
                         key={task.id}
@@ -455,7 +556,48 @@ export default function Home() {
                         } ${animatingId === task.id ? "opacity-50 scale-95" : ""}`}
                       >
                         {/* Main task row */}
-                        <div className="px-4 py-3.5 flex items-center gap-3">
+                        <div className="px-3 py-3.5 flex items-center gap-2">
+
+                          {/* 3-dot menu */}
+                          <div className="relative flex-shrink-0">
+                            <button
+                              onClick={e => {
+                                e.stopPropagation();
+                                setActiveMenuId(prev => prev === task.id ? null : task.id);
+                              }}
+                              className="w-6 h-6 flex items-center justify-center text-gray-400 hover:text-gray-600 rounded hover:bg-gray-100 transition-colors"
+                              aria-label="Task options"
+                            >
+                              <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 24 24">
+                                <circle cx="12" cy="5" r="1.5" />
+                                <circle cx="12" cy="12" r="1.5" />
+                                <circle cx="12" cy="19" r="1.5" />
+                              </svg>
+                            </button>
+                            {activeMenuId === task.id && (
+                              <div
+                                className="absolute left-0 top-7 z-20 bg-white border border-gray-200 rounded-lg shadow-lg py-1 min-w-[136px]"
+                                onClick={e => e.stopPropagation()}
+                              >
+                                <button
+                                  onClick={e => {
+                                    e.stopPropagation();
+                                    setAddingSubtaskForId(task.id);
+                                    setSubtaskInput("");
+                                    setActiveMenuId(null);
+                                  }}
+                                  className="w-full text-left px-3 py-2 text-xs text-gray-700 hover:bg-gray-50 flex items-center gap-2 transition-colors"
+                                >
+                                  <svg className="w-3.5 h-3.5 text-indigo-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                                    <path strokeLinecap="round" strokeLinejoin="round" d="M12 4v16m8-8H4" />
+                                  </svg>
+                                  Add Subtask
+                                </button>
+                              </div>
+                            )}
+                          </div>
+
+                          {/* Completion checkbox */}
                           <button
                             onClick={() => isConfirming ? cancelConfirm() : requestComplete(task)}
                             className={`w-5 h-5 rounded border-2 flex-shrink-0 transition-colors ${
@@ -465,19 +607,78 @@ export default function Home() {
                             }`}
                             aria-label={`Complete ${task.title}`}
                           />
+
+                          {/* Title and meta */}
                           <div className="flex-1 min-w-0">
                             <p className="text-sm font-medium text-gray-900 truncate">{task.title}</p>
-                            <p className="text-xs text-gray-400 mt-0.5 flex items-center gap-1">
+                            <p className="text-xs text-gray-400 mt-0.5 flex items-center gap-1.5">
                               <span>📅</span>
                               {fmtDate(task.createdAt)}
+                              {totalSubtasks > 0 && (
+                                <>
+                                  <span className="text-gray-200">·</span>
+                                  <span className={doneSubtasks === totalSubtasks ? "text-emerald-500" : "text-gray-400"}>
+                                    {doneSubtasks}/{totalSubtasks} subtasks
+                                  </span>
+                                </>
+                              )}
                             </p>
                           </div>
-                          <span className={`text-xs font-medium px-2 py-0.5 rounded-full ${PRIORITY_COLOR[task.priority]}`}>
+
+                          <span className={`text-xs font-medium px-2 py-0.5 rounded-full flex-shrink-0 ${PRIORITY_COLOR[task.priority]}`}>
                             {PRIORITY_LABEL[task.priority]}
                           </span>
                         </div>
 
-                        {/* More details toggle — only if task has tags or is useful */}
+                        {/* Subtasks section */}
+                        {(hasSubtasks || isAddingSubtask) && (
+                          <div className="px-3 pb-3 border-t border-gray-50">
+                            <div className="ml-8 space-y-1.5 pt-2">
+                              {task.subtasks.map(subtask => (
+                                <SubtaskRow
+                                  key={subtask.id}
+                                  subtask={subtask}
+                                  taskId={task.id}
+                                  onToggle={toggleSubtask}
+                                  onDelete={deleteSubtask}
+                                />
+                              ))}
+                              {isAddingSubtask && (
+                                <div className="flex items-center gap-2 pt-0.5">
+                                  <div className="w-4 h-4 rounded border-2 border-dashed border-gray-200 flex-shrink-0" />
+                                  <input
+                                    autoFocus
+                                    type="text"
+                                    placeholder="Subtask title…"
+                                    value={subtaskInput}
+                                    onChange={e => setSubtaskInput(e.target.value)}
+                                    onKeyDown={e => {
+                                      if (e.key === "Enter") { e.preventDefault(); addSubtask(task.id); }
+                                      if (e.key === "Escape") { setAddingSubtaskForId(null); setSubtaskInput(""); }
+                                    }}
+                                    className="flex-1 text-xs text-gray-800 placeholder-gray-400 bg-gray-50 border border-gray-200 rounded-md px-2 py-1.5 focus:outline-none focus:ring-1 focus:ring-indigo-300 focus:border-indigo-300"
+                                  />
+                                  <button
+                                    onClick={() => addSubtask(task.id)}
+                                    disabled={!subtaskInput.trim()}
+                                    className="px-2 py-1 bg-indigo-600 hover:bg-indigo-700 disabled:opacity-40 text-white text-xs font-medium rounded transition-colors"
+                                  >
+                                    Add
+                                  </button>
+                                  <button
+                                    onClick={() => { setAddingSubtaskForId(null); setSubtaskInput(""); }}
+                                    className="w-5 h-5 flex items-center justify-center text-gray-400 hover:text-gray-600 text-base leading-none"
+                                    aria-label="Cancel adding subtask"
+                                  >
+                                    ×
+                                  </button>
+                                </div>
+                              )}
+                            </div>
+                          </div>
+                        )}
+
+                        {/* More details toggle (tags) */}
                         {hasTags && (
                           <div className="px-4 pb-2">
                             <button
@@ -514,6 +715,11 @@ export default function Home() {
                               <p className="text-xs font-medium text-indigo-700 mb-2">
                                 Add a completion note <span className="text-gray-400 font-normal">(optional)</span>
                               </p>
+                              {totalSubtasks > 0 && doneSubtasks < totalSubtasks && (
+                                <p className="text-xs text-amber-600 bg-amber-50 border border-amber-100 rounded-lg px-3 py-2 mb-2">
+                                  {totalSubtasks - doneSubtasks} subtask{totalSubtasks - doneSubtasks !== 1 ? "s" : ""} will also be marked complete.
+                                </p>
+                              )}
                               <textarea
                                 autoFocus
                                 rows={2}
@@ -562,9 +768,10 @@ export default function Home() {
                 </h2>
                 <div className="space-y-2">
                   {completed.map(task => {
-                    const isExpanded = expandedTaskId === task.id;
-                    const hasTags    = task.tags && task.tags.length > 0;
-                    const hasDetails = hasTags || !!task.completionNote;
+                    const isExpanded  = expandedTaskId === task.id;
+                    const hasTags     = task.tags && task.tags.length > 0;
+                    const hasSubtasks = task.subtasks && task.subtasks.length > 0;
+                    const hasDetails  = hasTags || !!task.completionNote || hasSubtasks;
                     return (
                       <div
                         key={task.id}
@@ -584,9 +791,15 @@ export default function Home() {
                           </button>
                           <div className="flex-1 min-w-0">
                             <p className="text-sm text-gray-400 line-through truncate">{task.title}</p>
-                            <p className="text-xs text-gray-400 mt-0.5 flex items-center gap-1">
+                            <p className="text-xs text-gray-400 mt-0.5 flex items-center gap-1.5">
                               <span>✓</span>
                               {task.completedAt ? fmtDate(task.completedAt) : fmtDate(task.createdAt)}
+                              {hasSubtasks && (
+                                <>
+                                  <span className="text-gray-300">·</span>
+                                  <span>{task.subtasks.length} subtask{task.subtasks.length !== 1 ? "s" : ""}</span>
+                                </>
+                              )}
                             </p>
                           </div>
                           <span className={`text-xs font-medium px-2 py-0.5 rounded-full ${PRIORITY_COLOR[task.priority]}`}>
@@ -612,13 +825,32 @@ export default function Home() {
                             </button>
 
                             {isExpanded && (
-                              <div className="mt-2 space-y-2">
+                              <div className="mt-2 space-y-2.5">
                                 {task.completionNote && (
                                   <div className="px-3 py-2 bg-white border border-emerald-100 rounded-lg">
                                     <p className="text-xs text-gray-500 leading-relaxed">
                                       <span className="font-medium text-emerald-600">Note: </span>
                                       {task.completionNote}
                                     </p>
+                                  </div>
+                                )}
+                                {hasSubtasks && (
+                                  <div>
+                                    <p className="text-xs text-gray-400 font-medium mb-1.5">
+                                      Subtasks ({task.subtasks.length})
+                                    </p>
+                                    <div className="space-y-1">
+                                      {task.subtasks.map(st => (
+                                        <div key={st.id} className="flex items-center gap-2">
+                                          <div className="w-4 h-4 rounded border-2 border-emerald-400 bg-emerald-400 flex-shrink-0 flex items-center justify-center">
+                                            <svg className="w-2.5 h-2.5 text-white" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={3}>
+                                              <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
+                                            </svg>
+                                          </div>
+                                          <span className="text-xs line-through text-gray-400 truncate">{st.title}</span>
+                                        </div>
+                                      ))}
+                                    </div>
                                   </div>
                                 )}
                                 {hasTags && (

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -558,45 +558,6 @@ export default function Home() {
                         {/* Main task row */}
                         <div className="px-3 py-3.5 flex items-center gap-2">
 
-                          {/* 3-dot menu */}
-                          <div className="relative flex-shrink-0">
-                            <button
-                              onClick={e => {
-                                e.stopPropagation();
-                                setActiveMenuId(prev => prev === task.id ? null : task.id);
-                              }}
-                              className="w-6 h-6 flex items-center justify-center text-gray-400 hover:text-gray-600 rounded hover:bg-gray-100 transition-colors"
-                              aria-label="Task options"
-                            >
-                              <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 24 24">
-                                <circle cx="12" cy="5" r="1.5" />
-                                <circle cx="12" cy="12" r="1.5" />
-                                <circle cx="12" cy="19" r="1.5" />
-                              </svg>
-                            </button>
-                            {activeMenuId === task.id && (
-                              <div
-                                className="absolute left-0 top-7 z-20 bg-white border border-gray-200 rounded-lg shadow-lg py-1 min-w-[136px]"
-                                onClick={e => e.stopPropagation()}
-                              >
-                                <button
-                                  onClick={e => {
-                                    e.stopPropagation();
-                                    setAddingSubtaskForId(task.id);
-                                    setSubtaskInput("");
-                                    setActiveMenuId(null);
-                                  }}
-                                  className="w-full text-left px-3 py-2 text-xs text-gray-700 hover:bg-gray-50 flex items-center gap-2 transition-colors"
-                                >
-                                  <svg className="w-3.5 h-3.5 text-indigo-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-                                    <path strokeLinecap="round" strokeLinejoin="round" d="M12 4v16m8-8H4" />
-                                  </svg>
-                                  Add Subtask
-                                </button>
-                              </div>
-                            )}
-                          </div>
-
                           {/* Completion checkbox */}
                           <button
                             onClick={() => isConfirming ? cancelConfirm() : requestComplete(task)}
@@ -628,6 +589,45 @@ export default function Home() {
                           <span className={`text-xs font-medium px-2 py-0.5 rounded-full flex-shrink-0 ${PRIORITY_COLOR[task.priority]}`}>
                             {PRIORITY_LABEL[task.priority]}
                           </span>
+
+                          {/* 3-dot menu */}
+                          <div className="relative flex-shrink-0">
+                            <button
+                              onClick={e => {
+                                e.stopPropagation();
+                                setActiveMenuId(prev => prev === task.id ? null : task.id);
+                              }}
+                              className="w-7 h-7 flex items-center justify-center text-gray-500 hover:text-gray-900 rounded-md hover:bg-gray-100 transition-colors"
+                              aria-label="Task options"
+                            >
+                              <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 24 24">
+                                <circle cx="12" cy="5" r="1.5" />
+                                <circle cx="12" cy="12" r="1.5" />
+                                <circle cx="12" cy="19" r="1.5" />
+                              </svg>
+                            </button>
+                            {activeMenuId === task.id && (
+                              <div
+                                className="absolute right-0 top-8 z-20 bg-white border border-gray-200 rounded-lg shadow-lg py-1 min-w-[136px]"
+                                onClick={e => e.stopPropagation()}
+                              >
+                                <button
+                                  onClick={e => {
+                                    e.stopPropagation();
+                                    setAddingSubtaskForId(task.id);
+                                    setSubtaskInput("");
+                                    setActiveMenuId(null);
+                                  }}
+                                  className="w-full text-left px-3 py-2 text-xs text-gray-700 hover:bg-gray-50 flex items-center gap-2 transition-colors"
+                                >
+                                  <svg className="w-3.5 h-3.5 text-indigo-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                                    <path strokeLinecap="round" strokeLinejoin="round" d="M12 4v16m8-8H4" />
+                                  </svg>
+                                  Add Subtask
+                                </button>
+                              </div>
+                            )}
+                          </div>
                         </div>
 
                         {/* Subtasks section */}
@@ -790,7 +790,7 @@ export default function Home() {
                             </svg>
                           </button>
                           <div className="flex-1 min-w-0">
-                            <p className="text-sm text-gray-400 line-through truncate">{task.title}</p>
+                            <p className="text-sm text-gray-400 truncate">{task.title}</p>
                             <p className="text-xs text-gray-400 mt-0.5 flex items-center gap-1.5">
                               <span>✓</span>
                               {task.completedAt ? fmtDate(task.completedAt) : fmtDate(task.createdAt)}

--- a/frontend/src/app/types.ts
+++ b/frontend/src/app/types.ts
@@ -1,6 +1,14 @@
 export type TaskStatus   = "PENDING" | "COMPLETED";
 export type TaskPriority = "LOW" | "MEDIUM" | "HIGH";
 
+export interface Subtask {
+  id:          string;
+  title:       string;
+  status:      TaskStatus;
+  createdAt:   string;
+  completedAt: string | null;
+}
+
 export interface Task {
   id:             string;
   title:          string;
@@ -10,6 +18,7 @@ export interface Task {
   completedAt:    string | null;
   completionNote: string | null;
   tags:           string[];
+  subtasks:       Subtask[];
 }
 
 export interface DayStat {


### PR DESCRIPTION
## Summary

Adds subtask support to TaskEcho. Any pending task can now have a flat list of subtasks added at any point before it is completed. Individual subtasks have their own checkboxes; completing the main task auto-completes all remaining subtasks via a backend cascade.

## Changes

### Frontend
- New `SubtaskRow` component — checkbox, title (strikethrough when done), hover-reveal delete button
- 3-dot menu (⋮) on the right of each pending task card opens a dropdown with "Add Subtask"
- Inline subtask input below the task card — Enter to add (stays open for more), Escape/× to cancel
- Subtask progress counter (`x/y subtasks`) in the task meta line, turns emerald when all done
- Amber warning banner in the completion confirm panel when pending subtasks will be auto-completed
- Completed task "More details" section now shows all subtasks (checked/strikethrough)
- Removed `line-through` on completed task titles — muted colour and green checkbox communicate completion

### Backend
- New `Subtask.java` model (`id`, `title`, `status`, `createdAt`, `completedAt`)
- `Task.java` gains a `List<Subtask> subtasks` field with `addSubtask` / `removeSubtask` mutation methods
- `TaskService` — `addSubtask`, `updateSubtask`, `deleteSubtask`; `update()` cascades completion to all pending subtasks
- Three new REST endpoints under `/tasks/{id}/subtasks`

### Documentation
- `docs/features/subtasks.md` — full feature doc (functional changes, technical design, decisions, testing checklist)
- `docs/FEATURES.md` — subtasks entry added, version table updated to 1.5.0
- `README.md` API Reference — create-task response updated with `priority`/`tags`/`subtasks` fields; subtask endpoints added

## Technical Details

**Files Created:**
- `backend/src/main/java/com/taskecho/model/Subtask.java`
- `docs/features/subtasks.md`

**Files Modified:**
- `backend/src/main/java/com/taskecho/model/Task.java`
- `backend/src/main/java/com/taskecho/service/TaskService.java`
- `backend/src/main/java/com/taskecho/controller/TaskController.java`
- `frontend/src/app/types.ts`
- `frontend/src/app/page.tsx`
- `docs/FEATURES.md`
- `README.md`

**API Changes:**
- `POST /tasks/{id}/subtasks` — Add a subtask; body: `{ "title": "..." }`
- `PUT /tasks/{id}/subtasks/{subtaskId}` — Toggle status; body: `{ "status": "COMPLETED" }`
- `DELETE /tasks/{id}/subtasks/{subtaskId}` — Remove a subtask
- All three return the full updated `Task` object

**Breaking Changes:**
- None. `subtasks` is a new field on `Task` (defaults to `[]`); all existing API consumers are unaffected.

## Testing

- [x] Menu opens and closes on click; closes on outside click
- [x] "Add Subtask" opens inline input; Enter adds and keeps input open; Escape/x closes
- [x] Individual subtask completion updates only that subtask (checkbox + strikethrough)
- [x] Progress counter (`x/y subtasks`) updates in real time
- [x] Warning banner shows correct count of pending subtasks before main task completion
- [x] Completing main task cascades to all pending subtasks (verified via browser and API)
- [x] Completed task "More details" shows all subtasks checked/strikethrough
- [x] Subtask delete (hover x button) removes the subtask instantly
- [x] `POST /tasks/{id}/subtasks` on a completed task returns an error

**How to Test:**
1. Start backend (`cd backend && mvn spring-boot:run`) and frontend (`cd frontend && npm run dev`)
2. Create a task, click the three-dot menu, click "Add Subtask", add 2-3 subtasks
3. Check one subtask — only that row should update
4. Click the main task checkbox — confirm the amber warning shows the correct pending count
5. Mark complete — all subtasks should appear as complete in "More details"

## Related Issues

Closes feature request: subtasks support

## Checklist
- [x] Code follows project style guidelines
- [x] Documentation is updated (`README.md`, `docs/FEATURES.md`, `docs/features/subtasks.md`)
- [x] No breaking changes
- [x] Manually tested end-to-end in browser
- [x] No hardcoded values or secrets

Generated with [Claude Code](https://claude.com/claude-code)
